### PR TITLE
Add Localization Workflow Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@
 - [ElectronJS i18n](https://www.electronjs.org/apps/i18n-manager) - cross-platform i18n manager
 - [OmegaT](https://omegat.org) - free translation memory application that works on all popular operating systems
 - [LibreTranslate](https://github.com/uav4geo/LibreTranslate) - self-hosted web application to translate texts
+- [Localization Workflow Studio](https://github.com/zhangzeyu99-web/localization-workflow-studio) - local-first Excel workflow studio for game localization QA gates
 - [LRM](https://github.com/nickprotop/LocalizationManager) - cross-platform CLI for managing JSON (i18next compatible) and .resx localization files
 - [Fink](https://inlang.com/m/tdozzpar/app-inlang-editor) - git-based editor in the browser that connects to your repo
 


### PR DESCRIPTION
Adds Localization Workflow Studio to the translation management apps section.

Why it fits:
- local-first workflow app for game localization
- focuses on Excel language tables, QA gates, and delivery artifacts
- does not require a paid hosted service to work

I kept the entry short and avoided marketing copy.