### PR TITLE
Add enum-plus to apps and extensions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@
 - [LRM](https://github.com/nickprotop/LocalizationManager) - cross-platform CLI for managing JSON (i18next compatible) and .resx localization files
 - [Fink](https://inlang.com/m/tdozzpar/app-inlang-editor) - git-based editor in the browser that connects to your repo
 - [i18n-convert](https://github.com/i18n-agent/i18n-convert) - cli that losslessly converts between i18n file formats
+- [enum-plus](https://github.com/shijistar/enum-plus) - localized labels, badges and dropdown options straight from your enums, with React/Vue/Next plugins
 
 
 ## Text translation services


### PR DESCRIPTION
Adding [enum-plus](https://github.com/shijistar/enum-plus) to the **Apps and extensions for translation management** section.

It's a drop-in replacement for the native TS enum that turns enums into a lightweight **business-dictionary data source** with i18n baked in: labels resolve through plugin-i18next, plugin-vue-i18n and plugin-next-international, and results can bind to badges/dropdowns in React and Vue. 0 runtime dependencies, MIT.

- Repo: https://github.com/shijistar/enum-plus
- Docs: https://shijistar.github.io/enum-plus